### PR TITLE
Fixed missing /var/cache/swift directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -56,6 +56,7 @@ RUN	easy_install supervisor; mkdir /var/log/supervisor/ && \
     cp /usr/local/src/swift/test/sample.conf /etc/swift/test.conf && \
     sed -i 's/\$PrivDropToGroup syslog/\$PrivDropToGroup adm/' /etc/rsyslog.conf && \
     mkdir -p /var/log/swift/hourly; chown -R syslog.adm /var/log/swift; chmod -R g+w /var/log/swift && \
+    mkdir -p /var/cache/swift; chown -R swift:swift /var/cache/swift && \
     echo swift:fingertips | chpasswd; usermod -a -G sudo swift && \
     echo %sudo ALL=NOPASSWD: ALL >> /etc/sudoers
 


### PR DESCRIPTION
Thousands of errors were accumulating in /var/log/swift/storage1.error:
```
Jan 24 03:28:24 25efd6bd1866 object-auditor: Exception dumping recon cache: [Errno 2] No such file or directory: '/var/cache/swift/object.recon': #012Traceback (most recent call last):#012  File "/usr/local/src/swift/swift/common/utils.py", line 3650, in dump_recon_cache#012    with lock_file(cache_file, lock_timeout, unlink=False) as cf:#012  File "/usr/lib/python2.7/contextlib.py", line 17, in __enter__#012    return self.gen.next()#012  File "/usr/local/src/swift/swift/common/utils.py", line 2848, in lock_file#012    fd = os.open(filename, flags)#012OSError: [Errno 2] No such file or directory: '/var/cache/swift/object.recon'
```
This was caused by a missing /var/cache/swift directory in the container filesystem.
This commit fixes that in the Dockerfile.